### PR TITLE
Add life counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Purrito commands use the plus symbol '+' as a prefix.
 
 Purrito will respond to approximately 5% of messages with a 'Meow.'. It also has the following user commands
 
-| Command  | Parameters                           | Behaviour                                                                                                  |
-| -------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `+speak` | -                                    | Sends `Meow!` to the channel .                                                                             |
-| `+do`    | verb or sentence beginning with verb | Responds with italised message with Purrito carryingout the action. e.g. `+do glare` -> _`purrito glares`_ |
-| `+ping`  | -                                    | Responds with the round-trip latency between sending a message and editing it.                             |
+| Command      | Parameters                           | Behaviour                                                                                                                        |
+| ------------ | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `+speak`     | -                                    | Sends `Meow!` to the channel .                                                                                                   |
+| `+do`        | verb or sentence beginning with verb | Responds with italised message with Purrito carryingout the action. e.g. `+do glare` -> _`purrito glares`_                       |
+| `+ping`      | -                                    | Responds with the round-trip latency between sending a message and editing it.                                                   |
+| `+die`       | -                                    | Lowers Purrito's life count by 1. If it hits 0, no commands other than `+resurrect` will work until Purrito has at least 1 life. |
+| `+resurrect` | -                                    | Raises Purrito's life count by 1.                                                                                                |
 
 ## :runner: Running your own Purrito
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -619,15 +619,6 @@
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
         },
-        "@types/winston": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-            "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-            "dev": true,
-            "requires": {
-                "winston": "*"
-            }
-        },
         "@types/yargs": {
             "version": "15.0.4",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -2461,6 +2452,14 @@
                 "istanbul-lib-report": "^3.0.0"
             }
         },
+        "javascript-time-ago": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.0.7.tgz",
+            "integrity": "sha512-NjM8FNqY91lciAE4bIm6KBW1efDt+0T6+08erwaQRu6SzLov8fJ6623LcyxnBN/Xtf4q9O4s5AMxPtStaNz0rA==",
+            "requires": {
+                "relative-time-format": "^0.1.3"
+            }
+        },
         "jest": {
             "version": "25.1.0",
             "resolved": "https://registry.npmjs.org/jest/-/jest-25.1.0.tgz",
@@ -3283,6 +3282,11 @@
                 "minimist": "^1.2.5"
             }
         },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
         "mongodb": {
             "version": "3.5.5",
             "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",
@@ -3799,6 +3803,11 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
             }
+        },
+        "relative-time-format": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/relative-time-format/-/relative-time-format-0.1.3.tgz",
+            "integrity": "sha512-0O6i4fKjsx8qhz57zorG+LrIDnF9pSvP5s7H9R1Nb5nSqih5dvRyKzNKs6MxhL3bv4iwsz4DuDwAyw+c47QFIA=="
         },
         "remove-trailing-separator": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
         "deep-equal": "^2.0.1",
         "discord.js": "^12.0.2",
         "dotenv": "^8.2.0",
-        "winston": "^3.2.1",
-        "mongoose": "^5.9.5"
+        "javascript-time-ago": "^2.0.7",
+        "moment": "^2.24.0",
+        "mongoose": "^5.9.5",
+        "winston": "^3.2.1"
     },
     "devDependencies": {
         "@types/deep-equal": "^1.0.1",

--- a/src/commands/dies.ts
+++ b/src/commands/dies.ts
@@ -1,0 +1,25 @@
+import { Message } from 'discord.js'
+import { findOrMakeGuild } from '../utils'
+import moment from 'moment'
+import { logger } from '../logger'
+
+export default async function die(message: Message) {
+    const guildId = message.guild!.id
+    const guild = await findOrMakeGuild(guildId)
+    let response: string
+    guild.purritoState.lives = guild.purritoState.lives - 1
+    if (guild.purritoState.lives >= 1) {
+        response = `*purrito dies.* he has ${guild.purritoState.lives} ${
+            guild.purritoState.lives > 1 ? 'lives' : 'life'
+        } left. :skull_crossbones:`
+    } else if (guild.purritoState.lives === 0) {
+        const timeOfDeath = moment()
+        guild.purritoState.timeOfDeath = timeOfDeath.toDate()
+        response = `*purrito dies.* he's unresponsive... Time of death: ${timeOfDeath.toLocaleString()}`
+    } else {
+        guild.purritoState.lives = 0
+        response = `How do you kill that which has no life?`
+    }
+    await guild.save()
+    return await message.channel.send(response)
+}

--- a/src/commands/dies.ts
+++ b/src/commands/dies.ts
@@ -9,13 +9,13 @@ export default async function die(message: Message) {
     let response: string
     guild.purritoState.lives = guild.purritoState.lives - 1
     if (guild.purritoState.lives >= 1) {
-        response = `*purrito dies.* he has ${guild.purritoState.lives} ${
+        response = `*purrito dies.* He has ${guild.purritoState.lives} ${
             guild.purritoState.lives > 1 ? 'lives' : 'life'
         } left. :skull_crossbones:`
     } else if (guild.purritoState.lives === 0) {
         const timeOfDeath = moment()
         guild.purritoState.timeOfDeath = timeOfDeath.toDate()
-        response = `*purrito dies.* he's unresponsive... Time of death: ${timeOfDeath.toLocaleString()}`
+        response = `*purrito dies.* He's unresponsive... Time of death: ${timeOfDeath.toLocaleString()}`
     } else {
         guild.purritoState.lives = 0
         response = `How do you kill that which has no life?`

--- a/src/commands/resurrect.ts
+++ b/src/commands/resurrect.ts
@@ -1,0 +1,20 @@
+import { findOrMakeGuild } from '../utils'
+import { Message } from 'discord.js'
+
+export default async function resurrect(message: Message) {
+    const guildId = message.guild!.id
+    const guild = await findOrMakeGuild(guildId)
+    let response: string
+    guild.purritoState.lives = guild.purritoState.lives + 1
+    if (guild.purritoState.lives <= 8) {
+        guild.purritoState.timeOfDeath = null
+        response = `*purrito is resurrected.* he has ${
+            guild.purritoState.lives
+        } ${guild.purritoState.lives > 1 ? 'lives' : 'life'} left. :heart:`
+    } else {
+        guild.purritoState.lives = 9
+        response = `*purrito can't get any more alive!*`
+    }
+    await guild.save()
+    return await message.channel.send(response)
+}

--- a/src/commands/setConfig.ts
+++ b/src/commands/setConfig.ts
@@ -2,7 +2,7 @@ import { Message } from 'discord.js'
 import Guild, { GuildSettings } from '../models/guild'
 import config from '../config.json'
 import equal from 'deep-equal'
-import { allConfigAsMessageString } from '../utils'
+import { allConfigAsMessageString, findOrMakeGuild } from '../utils'
 
 export async function setConfig(message: Message, args: string[]) {
     let [key, value] = args
@@ -33,19 +33,6 @@ function updateSettings(key: string, value: string, settings: GuildSettings) {
         default:
             throw new Error(`Invalid config option "${key}"`)
     }
-}
-
-async function findOrMakeGuild(guildId: string) {
-    // Try to get existing guild config
-    let guild = await Guild.findOne({ guildId: guildId })
-    if (!guild) {
-        // Create config if none exists yet for this guild
-        guild = new Guild({
-            guildId: guildId,
-            settings: config.defaultSettings,
-        })
-    }
-    return guild
 }
 
 function updateRandomSpeechProbability(value: string, settings: GuildSettings) {

--- a/src/config.json
+++ b/src/config.json
@@ -2,5 +2,8 @@
     "prefix": "+",
     "defaultSettings": {
         "randomSpeechProbability": 0.05
+    },
+    "defaultPurritoState": {
+        "lives": 9
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Client, Message } from 'discord.js'
 import dotenv from 'dotenv'
 import { speak } from './commands/speak'
 import config from './config.json'
-import { executeCommand } from './utils'
+import { executeCommand, findOrMakeGuild } from './utils'
 import { parseDiceMaidenMessage } from './DiceMaiden/ParseDiceMaiden'
 import { logger } from './logger'
 import * as fs from 'fs'
@@ -76,8 +76,8 @@ client.on('message', async (message: Message) => {
     // Ignore bots
     if (message.author.bot) return
 
-    // On messages without prefix run these commands
     if (message.content.indexOf(config.prefix) !== 0) {
+        // On messages without prefix run these commands
         // Randomly meow when a message is received
         if (Math.random() < guildSettings.randomSpeechProbability) {
             speak(message)

--- a/src/models/guild.ts
+++ b/src/models/guild.ts
@@ -1,12 +1,19 @@
 import mongoose, { Schema, Document, Model } from 'mongoose'
+import config from '../config.json'
 
 export interface GuildSettings {
     randomSpeechProbability: number
 }
 
+export interface PurritoState {
+    lives: number
+    timeOfDeath: Date | null
+}
+
 export interface IGuild extends Document {
     guildId: string
     settings: GuildSettings
+    purritoState: PurritoState
 }
 
 export interface IGuildModel extends Model<IGuild> {
@@ -17,6 +24,10 @@ const GuildSchema: Schema = new Schema({
     guildId: { type: String, required: true, unique: true },
     settings: {
         randomSpeechProbability: Number,
+    },
+    purritoState: {
+        lives: Number,
+        timeOfDeath: Date,
     },
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "allowSyntheticDefaultImports": true,
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "isolatedModules": true
+        "isolatedModules": true,
+        "noImplicitAny": false
     },
 
     "include": ["src"],


### PR DESCRIPTION
# Description

Adds a life counter to the database. using the `+die` command decrements this from default starting point of 9 down to 0. When lives hit 0, no commands other than `+resurrect` will work. 

closes #43 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Purrito development server 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
